### PR TITLE
Fix #24 Inconsistency documentation handling missing language

### DIFF
--- a/public/documentation/guide-customize.md
+++ b/public/documentation/guide-customize.md
@@ -161,4 +161,4 @@ from the dropdown.
 3. Click on the 'Edit row' icon before the row you want to edit.
 4. Provide a translation for each available language.
 
-Missing translations will show up as #msgid# in the user interface.
+Missing translations will show up in English in the user interface.


### PR DESCRIPTION
Due to the recent decision for issue #4334 (https://github.com/molgenis/molgenis.org/issues/new) to change the labels of for a missing language to English the documentation is inconsistent.
The current documentation states: "Missing translations will show up as #msgid# in the user interface".
